### PR TITLE
Test/send ai result

### DIFF
--- a/src/handlers/game_log_handler.py
+++ b/src/handlers/game_log_handler.py
@@ -5,6 +5,33 @@ from ..utils.packet_sender import send_response
 from ..utils.redis.redis import GameRedis
 from google.protobuf.json_format import MessageToDict
 
+def build_support_payload(ai_result: dict) -> dict:
+    """
+    AI 결과에서 의미 있는 support 효과만 추출하여 payload 형식으로 구성
+    """
+    support_payload = {}
+
+    for key, value in ai_result.items():
+        # area_* 계열 (dict 타입 필수)
+        if key.startswith("area_") and isinstance(value, dict):
+            if "range" in value and "value" in value:
+                support_payload[key] = {
+                    "range": value["range"],
+                    "value": value["value"]
+                }
+            continue
+
+        if value is None:
+            continue
+
+        if isinstance(value, (int, float)) and value == 0:
+            continue
+
+        support_payload[key] = value
+
+    return {"support": support_payload}
+
+
 async def game_log_handler(context):
     try:
         socket = context['socket']
@@ -14,25 +41,27 @@ async def game_log_handler(context):
 
         data_dict = MessageToDict(packet)
         await GameRedis.push_game_log(account_id, data_dict)
-        print(f"게임 로그 Redis에 저장 완료: {data_dict}")
+        print(f"게임 로그 Redis에 저장 완료: {data_dict}\n")
 
         # ✅ AI 분석 로직 자리 (예시)
         # logs = await GameRedis.get_recent_logs(account_id) // Redis에서 로그 가져오는 코드
-        # result = await run_ai(logs)
-        # if result["need_support"]:
-        #     payload에 해당 값 담아서 send_response
+        # ai_result = await run_ai(logs)
 
-        need_support = False  # send_response 우회 // AI 추가 전 로그 확인용
-
-        if not need_support:
-            print("\n[AI 우회] 지원 불필요 판단, 응답 생략.\n")
-            return
-
-        payload = {
-            # 필요한 값 담아서
-            # packet.proto 파일에서 S_RESULT 타입 수정 필요 (현재는 빈 객체)
+        # 테스트용 더미 AI 결과
+        ai_result = {
+            "shield_active": 1.0,
+            "speed_up": 2.5,
+            "area_slow": {"range": 5.0, "value": 0.3},
+            "crit_boost": None,
+            "cooldown_reduction": 0
         }
 
-        await send_response(SuccessCode['Success'], '서포팅 결과 전송 완료', payload_types['S_RESULT'], payload)
+        payload = build_support_payload(ai_result)
+
+        if not payload["support"]:
+            print("\n[AI 우회] 유효한 서포트 항목 없음 → 응답 생략.\n")
+            return
+
+        await send_response(socket, SuccessCode['Success'], '서포팅 결과 전송 완료', payload_types['S_RESULT'], payload)
     except Exception as error:
         await handle_error(socket, error)

--- a/src/protobuf/packet.proto
+++ b/src/protobuf/packet.proto
@@ -87,7 +87,30 @@ message OrnamentSlot {
 }
 
 message S_Result {
+  Supporting support = 1;
+}
 
+message Supporting {
+  float shield_active = 1; 
+  int32 invincibility = 2;
+  bool boss_buff = 3;
+  bool hp_guard = 4;
+  float periodic_heal = 5;
+  float speed_up = 6;
+  float attack_speed_up = 7;
+  float attack_up = 8;
+  int32 defense_up = 9;
+  float cooldown_reduction = 10;
+  float berserk_mode = 11;
+  float crit_boost = 12;
+  float xp_boost = 13;
+  AreaEffect area_slow = 14;
+  AreaEffect area_protect = 15;
+}
+
+message AreaEffect {
+  float range = 1;     // 적용 범위
+  float value = 2;     // 효과 수치
 }
 
 message PingPacket {

--- a/src/protobuf/packet_pb2.py
+++ b/src/protobuf/packet_pb2.py
@@ -6,9 +6,17 @@
 """Generated protocol buffer code."""
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import descriptor_pool as _descriptor_pool
-
+from google.protobuf import runtime_version as _runtime_version
 from google.protobuf import symbol_database as _symbol_database
 from google.protobuf.internal import builder as _builder
+_runtime_version.ValidateProtobufRuntimeVersion(
+    _runtime_version.Domain.PUBLIC,
+    6,
+    30,
+    2,
+    '',
+    'packet.proto'
+)
 # @@protoc_insertion_point(imports)
 
 _sym_db = _symbol_database.Default()
@@ -16,17 +24,17 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cpacket.proto\x12\x18Google.Protobuf.Protocol\"\t\n\x07\x43_Enter\"?\n\x07S_Enter\x12\x34\n\x06player\x18\x01 \x01(\x0b\x32$.Google.Protobuf.Protocol.PlayerData\"=\n\x05\x43_Log\x12\x34\n\x06player\x18\x01 \x01(\x0b\x32$.Google.Protobuf.Protocol.PlayerData\"\x8f\x06\n\nPlayerData\x12\x10\n\x08playerId\x18\x01 \x01(\t\x12\r\n\x05level\x18\x02 \x01(\x05\x12\x0b\n\x03\x65xp\x18\x03 \x01(\x02\x12\x0c\n\x04posX\x18\x04 \x01(\x02\x12\x0c\n\x04posY\x18\x05 \x01(\x02\x12\x0c\n\x04posZ\x18\x06 \x01(\x02\x12\x11\n\tmoveSpeed\x18\x07 \x01(\x02\x12\x11\n\tcurrentHp\x18\x08 \x01(\x02\x12\r\n\x05maxHp\x18\t \x01(\x02\x12\x11\n\thealSpeed\x18\n \x01(\x02\x12\x10\n\x08\x61tkPower\x18\x0b \x01(\x02\x12\x10\n\x08\x61tkSpeed\x18\x0c \x01(\x02\x12\x10\n\x08maxSpeed\x18\r \x01(\x02\x12\x16\n\x0e\x63riticalChance\x18\x0e \x01(\x02\x12\x1a\n\x12\x63riticalMultiplier\x18\x0f \x01(\x02\x12\x16\n\x0e\x64\x65\x66\x65nsivePower\x18\x10 \x01(\x02\x12\x10\n\x08\x63ooldown\x18\x11 \x01(\x02\x12\x0e\n\x06magnet\x18\x12 \x01(\x02\x12\x10\n\x08hitCount\x18\x13 \x01(\x05\x12\x18\n\x10totalDamageTaken\x18\x14 \x01(\x02\x12\x13\n\x0btotalDamage\x18\x15 \x01(\x02\x12\x13\n\x0bnumMonsters\x18\x16 \x01(\x05\x12\x14\n\x0cnearMonsters\x18\x17 \x01(\x05\x12\x14\n\x0ckillMonsters\x18\x18 \x01(\x05\x12\x0b\n\x03kpm\x18\x19 \x01(\x02\x12\x13\n\x0busedHPitems\x18\x1a \x01(\x05\x12\x14\n\x0c\x64\x65letedItems\x18\x1b \x01(\x05\x12\x15\n\rnumEquipments\x18\x1c \x01(\x05\x12\x14\n\x0cnumOrnaments\x18\x1d \x01(\x05\x12>\n\requipmentSlot\x18\x1e \x03(\x0b\x32\'.Google.Protobuf.Protocol.EquipmentSlot\x12<\n\x0cornamentSlot\x18\x1f \x03(\x0b\x32&.Google.Protobuf.Protocol.OrnamentSlot\x12\r\n\x05score\x18  \x01(\x02\x12\x14\n\x0csurvivalTime\x18! \x01(\x02\x12\x10\n\x08soulCont\x18\" \x01(\x05\x12\x10\n\x08keyCount\x18# \x01(\x05\x12\x0f\n\x07IsAlive\x18$ \x01(\x08\"\"\n\rEquipmentSlot\x12\x11\n\tequipment\x18\x01 \x01(\x05\" \n\x0cOrnamentSlot\x12\x10\n\x08ornament\x18\x01 \x01(\x05\"\n\n\x08S_Result\"\x1f\n\nPingPacket\x12\x11\n\ttimestamp\x18\x01 \x01(\x04\"8\n\nPongPacket\x12\x11\n\ttimestamp\x18\x01 \x01(\x04\x12\x17\n\x0fserverTimestamp\x18\x02 \x01(\x04\"\xd8\x01\n\rRequestPacket\x12\x13\n\x0bpayloadType\x18\x01 \x01(\r\x12\x33\n\x06\x63\x45nter\x18\x02 \x01(\x0b\x32!.Google.Protobuf.Protocol.C_EnterH\x00\x12/\n\x04\x63Log\x18\x03 \x01(\x0b\x32\x1f.Google.Protobuf.Protocol.C_LogH\x00\x12\x41\n\rcQuestRequest\x18\x04 \x01(\x0b\x32(.Google.Protobuf.Protocol.C_QuestRequestH\x00\x42\t\n\x07payload\"\x93\x02\n\x0eResponsePacket\x12\x0c\n\x04\x63ode\x18\x01 \x01(\r\x12\x0f\n\x07message\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\x04\x12\x13\n\x0bpayloadType\x18\x04 \x01(\r\x12\x33\n\x06sEnter\x18\x05 \x01(\x0b\x32!.Google.Protobuf.Protocol.S_EnterH\x00\x12\x35\n\x07sResult\x18\x06 \x01(\x0b\x32\".Google.Protobuf.Protocol.S_ResultH\x00\x12\x43\n\x0esQuestResponse\x18\x07 \x01(\x0b\x32).Google.Protobuf.Protocol.S_QuestResponseH\x00\x42\t\n\x07payload\"F\n\x0e\x43_QuestRequest\x12\x34\n\x06player\x18\x01 \x01(\x0b\x32$.Google.Protobuf.Protocol.PlayerData\"$\n\x0fS_QuestResponse\x12\x11\n\tquestText\x18\x01 \x01(\t*O\n\x08PacketId\x12\x14\n\x10UNDEFINED_PACKET\x10\x00\x12\x08\n\x04PING\x10\x01\x12\x08\n\x04PONG\x10\x02\x12\x0b\n\x07REQUEST\x10\x03\x12\x0c\n\x08RESPONSE\x10\x04*|\n\x05MsgId\x12\x15\n\x11UNDEFINED_PAYLOAD\x10\x00\x12\x0b\n\x07\x43_ENTER\x10\x01\x12\x0b\n\x07S_ENTER\x10\x02\x12\t\n\x05\x43_LOG\x10\x03\x12\x0c\n\x08S_RESULT\x10\x04\x12\x13\n\x0f\x43_QUEST_REQUEST\x10\x05\x12\x14\n\x10S_QUEST_RESPONSE\x10\x06\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cpacket.proto\x12\x18Google.Protobuf.Protocol\"\t\n\x07\x43_Enter\"?\n\x07S_Enter\x12\x34\n\x06player\x18\x01 \x01(\x0b\x32$.Google.Protobuf.Protocol.PlayerData\"=\n\x05\x43_Log\x12\x34\n\x06player\x18\x01 \x01(\x0b\x32$.Google.Protobuf.Protocol.PlayerData\"\x8f\x06\n\nPlayerData\x12\x10\n\x08playerId\x18\x01 \x01(\t\x12\r\n\x05level\x18\x02 \x01(\x05\x12\x0b\n\x03\x65xp\x18\x03 \x01(\x02\x12\x0c\n\x04posX\x18\x04 \x01(\x02\x12\x0c\n\x04posY\x18\x05 \x01(\x02\x12\x0c\n\x04posZ\x18\x06 \x01(\x02\x12\x11\n\tmoveSpeed\x18\x07 \x01(\x02\x12\x11\n\tcurrentHp\x18\x08 \x01(\x02\x12\r\n\x05maxHp\x18\t \x01(\x02\x12\x11\n\thealSpeed\x18\n \x01(\x02\x12\x10\n\x08\x61tkPower\x18\x0b \x01(\x02\x12\x10\n\x08\x61tkSpeed\x18\x0c \x01(\x02\x12\x10\n\x08maxSpeed\x18\r \x01(\x02\x12\x16\n\x0e\x63riticalChance\x18\x0e \x01(\x02\x12\x1a\n\x12\x63riticalMultiplier\x18\x0f \x01(\x02\x12\x16\n\x0e\x64\x65\x66\x65nsivePower\x18\x10 \x01(\x02\x12\x10\n\x08\x63ooldown\x18\x11 \x01(\x02\x12\x0e\n\x06magnet\x18\x12 \x01(\x02\x12\x10\n\x08hitCount\x18\x13 \x01(\x05\x12\x18\n\x10totalDamageTaken\x18\x14 \x01(\x02\x12\x13\n\x0btotalDamage\x18\x15 \x01(\x02\x12\x13\n\x0bnumMonsters\x18\x16 \x01(\x05\x12\x14\n\x0cnearMonsters\x18\x17 \x01(\x05\x12\x14\n\x0ckillMonsters\x18\x18 \x01(\x05\x12\x0b\n\x03kpm\x18\x19 \x01(\x02\x12\x13\n\x0busedHPitems\x18\x1a \x01(\x05\x12\x14\n\x0c\x64\x65letedItems\x18\x1b \x01(\x05\x12\x15\n\rnumEquipments\x18\x1c \x01(\x05\x12\x14\n\x0cnumOrnaments\x18\x1d \x01(\x05\x12>\n\requipmentSlot\x18\x1e \x03(\x0b\x32\'.Google.Protobuf.Protocol.EquipmentSlot\x12<\n\x0cornamentSlot\x18\x1f \x03(\x0b\x32&.Google.Protobuf.Protocol.OrnamentSlot\x12\r\n\x05score\x18  \x01(\x02\x12\x14\n\x0csurvivalTime\x18! \x01(\x02\x12\x10\n\x08soulCont\x18\" \x01(\x05\x12\x10\n\x08keyCount\x18# \x01(\x05\x12\x0f\n\x07IsAlive\x18$ \x01(\x08\"\"\n\rEquipmentSlot\x12\x11\n\tequipment\x18\x01 \x01(\x05\" \n\x0cOrnamentSlot\x12\x10\n\x08ornament\x18\x01 \x01(\x05\"A\n\x08S_Result\x12\x35\n\x07support\x18\x01 \x01(\x0b\x32$.Google.Protobuf.Protocol.Supporting\"\x95\x03\n\nSupporting\x12\x15\n\rshield_active\x18\x01 \x01(\x02\x12\x15\n\rinvincibility\x18\x02 \x01(\x05\x12\x11\n\tboss_buff\x18\x03 \x01(\x08\x12\x10\n\x08hp_guard\x18\x04 \x01(\x08\x12\x15\n\rperiodic_heal\x18\x05 \x01(\x02\x12\x10\n\x08speed_up\x18\x06 \x01(\x02\x12\x17\n\x0f\x61ttack_speed_up\x18\x07 \x01(\x02\x12\x11\n\tattack_up\x18\x08 \x01(\x02\x12\x12\n\ndefense_up\x18\t \x01(\x05\x12\x1a\n\x12\x63ooldown_reduction\x18\n \x01(\x02\x12\x14\n\x0c\x62\x65rserk_mode\x18\x0b \x01(\x02\x12\x12\n\ncrit_boost\x18\x0c \x01(\x02\x12\x10\n\x08xp_boost\x18\r \x01(\x02\x12\x37\n\tarea_slow\x18\x0e \x01(\x0b\x32$.Google.Protobuf.Protocol.AreaEffect\x12:\n\x0c\x61rea_protect\x18\x0f \x01(\x0b\x32$.Google.Protobuf.Protocol.AreaEffect\"*\n\nAreaEffect\x12\r\n\x05range\x18\x01 \x01(\x02\x12\r\n\x05value\x18\x02 \x01(\x02\"\x1f\n\nPingPacket\x12\x11\n\ttimestamp\x18\x01 \x01(\x04\"8\n\nPongPacket\x12\x11\n\ttimestamp\x18\x01 \x01(\x04\x12\x17\n\x0fserverTimestamp\x18\x02 \x01(\x04\"\xd8\x01\n\rRequestPacket\x12\x13\n\x0bpayloadType\x18\x01 \x01(\r\x12\x33\n\x06\x63\x45nter\x18\x02 \x01(\x0b\x32!.Google.Protobuf.Protocol.C_EnterH\x00\x12/\n\x04\x63Log\x18\x03 \x01(\x0b\x32\x1f.Google.Protobuf.Protocol.C_LogH\x00\x12\x41\n\rcQuestRequest\x18\x04 \x01(\x0b\x32(.Google.Protobuf.Protocol.C_QuestRequestH\x00\x42\t\n\x07payload\"\x93\x02\n\x0eResponsePacket\x12\x0c\n\x04\x63ode\x18\x01 \x01(\r\x12\x0f\n\x07message\x18\x02 \x01(\t\x12\x11\n\ttimestamp\x18\x03 \x01(\x04\x12\x13\n\x0bpayloadType\x18\x04 \x01(\r\x12\x33\n\x06sEnter\x18\x05 \x01(\x0b\x32!.Google.Protobuf.Protocol.S_EnterH\x00\x12\x35\n\x07sResult\x18\x06 \x01(\x0b\x32\".Google.Protobuf.Protocol.S_ResultH\x00\x12\x43\n\x0esQuestResponse\x18\x07 \x01(\x0b\x32).Google.Protobuf.Protocol.S_QuestResponseH\x00\x42\t\n\x07payload\"F\n\x0e\x43_QuestRequest\x12\x34\n\x06player\x18\x01 \x01(\x0b\x32$.Google.Protobuf.Protocol.PlayerData\"$\n\x0fS_QuestResponse\x12\x11\n\tquestText\x18\x01 \x01(\t*O\n\x08PacketId\x12\x14\n\x10UNDEFINED_PACKET\x10\x00\x12\x08\n\x04PING\x10\x01\x12\x08\n\x04PONG\x10\x02\x12\x0b\n\x07REQUEST\x10\x03\x12\x0c\n\x08RESPONSE\x10\x04*|\n\x05MsgId\x12\x15\n\x11UNDEFINED_PAYLOAD\x10\x00\x12\x0b\n\x07\x43_ENTER\x10\x01\x12\x0b\n\x07S_ENTER\x10\x02\x12\t\n\x05\x43_LOG\x10\x03\x12\x0c\n\x08S_RESULT\x10\x04\x12\x13\n\x0f\x43_QUEST_REQUEST\x10\x05\x12\x14\n\x10S_QUEST_RESPONSE\x10\x06\x62\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
 _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'packet_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   DESCRIPTOR._loaded_options = None
-  _globals['_PACKETID']._serialized_start=1747
-  _globals['_PACKETID']._serialized_end=1826
-  _globals['_MSGID']._serialized_start=1828
-  _globals['_MSGID']._serialized_end=1952
+  _globals['_PACKETID']._serialized_start=2254
+  _globals['_PACKETID']._serialized_end=2333
+  _globals['_MSGID']._serialized_start=2335
+  _globals['_MSGID']._serialized_end=2459
   _globals['_C_ENTER']._serialized_start=42
   _globals['_C_ENTER']._serialized_end=51
   _globals['_S_ENTER']._serialized_start=53
@@ -40,17 +48,21 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_ORNAMENTSLOT']._serialized_start=1003
   _globals['_ORNAMENTSLOT']._serialized_end=1035
   _globals['_S_RESULT']._serialized_start=1037
-  _globals['_S_RESULT']._serialized_end=1047
-  _globals['_PINGPACKET']._serialized_start=1049
-  _globals['_PINGPACKET']._serialized_end=1080
-  _globals['_PONGPACKET']._serialized_start=1082
-  _globals['_PONGPACKET']._serialized_end=1138
-  _globals['_REQUESTPACKET']._serialized_start=1141
-  _globals['_REQUESTPACKET']._serialized_end=1357
-  _globals['_RESPONSEPACKET']._serialized_start=1360
-  _globals['_RESPONSEPACKET']._serialized_end=1635
-  _globals['_C_QUESTREQUEST']._serialized_start=1637
-  _globals['_C_QUESTREQUEST']._serialized_end=1707
-  _globals['_S_QUESTRESPONSE']._serialized_start=1709
-  _globals['_S_QUESTRESPONSE']._serialized_end=1745
+  _globals['_S_RESULT']._serialized_end=1102
+  _globals['_SUPPORTING']._serialized_start=1105
+  _globals['_SUPPORTING']._serialized_end=1510
+  _globals['_AREAEFFECT']._serialized_start=1512
+  _globals['_AREAEFFECT']._serialized_end=1554
+  _globals['_PINGPACKET']._serialized_start=1556
+  _globals['_PINGPACKET']._serialized_end=1587
+  _globals['_PONGPACKET']._serialized_start=1589
+  _globals['_PONGPACKET']._serialized_end=1645
+  _globals['_REQUESTPACKET']._serialized_start=1648
+  _globals['_REQUESTPACKET']._serialized_end=1864
+  _globals['_RESPONSEPACKET']._serialized_start=1867
+  _globals['_RESPONSEPACKET']._serialized_end=2142
+  _globals['_C_QUESTREQUEST']._serialized_start=2144
+  _globals['_C_QUESTREQUEST']._serialized_end=2214
+  _globals['_S_QUESTRESPONSE']._serialized_start=2216
+  _globals['_S_QUESTRESPONSE']._serialized_end=2252
 # @@protoc_insertion_point(module_scope)


### PR DESCRIPTION
- **S_Result 페이로드 추가**
Supporting support
범위효과에서 범위를 어디서 설정하는지 몰라서 일단 서버에서 결정한다는 가정하에 proto에 정의해놨습니다.
패킷 수정 후 bash에 `protoc -I="./src/protobuf" --python_out="./src/protobuf" "./src/protobuf/packet.proto"` 입력 필수

- **payload(ai_result) send_response 정상 작동 확인**
build_support_payload()는 AI 분석 결과에서 유효한 지원 효과만 걸러내어 프로토콜 전송용 payload로 구성하는 함수
`ai_result = {
            "변수명": 수치
        }`
![스크린샷 2025-05-21 213014](https://github.com/user-attachments/assets/36402e71-b10b-4961-9d78-b9d6d5b16b6d)